### PR TITLE
working dockerization for NON-GUI examples

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+README.md
+Dockerfile
+.dockerignore
+.gitignore
+.git
+logging.properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM gradle:6.8.0-jdk8
+WORKDIR /app
+COPY . /app
+USER root
+RUN chown -R gradle /app
+USER gradle
+RUN echo 'handlers= java.util.logging.ConsoleHandler' >logging.properties
+RUN gradle uberJar --stacktrace
+
+FROM jomifred/jacamo:1.0
+WORKDIR /app
+COPY --from=0 /app/build/libs /app
+CMD ["java", "-jar", "jacamo-overviewJaCaMo-1.0.jar"]


### PR DESCRIPTION
**Creating image**:
`docker image build . -t <IMAGE NAME>`

**Running container with created image**:
`docker container run --name <CONTAINER NAME> <IMAGE NAME>`
Apparently shutting down with _CTRL + C_ here doesn't work and I don't know why. This means that you have to manually stop the run from the docker gui or another terminal with the last command.

**Running container with created image in detached mode**:
`docker container run -d --name <CONTAINER NAME> <IMAGE NAME>`

**Seeing log from detached mode**:
`docker logs -f <CONTAINER NAME>`

**Stopping the running container**:
`docker container stop <CONTAINER NAME>`

**Important details**:
In order to prevent X11 DISPLAY env variable error at running time, while creating the image ,I ignored the _logging.properties_ file (see _.dockerignore_) and created a brand new _logging.properties_ file that tells JaCaMo to use the terminal for the output, instead of the MAS gui (see _Dockerfile_ line 7).
This works with examples that does not involve a gui other than the MAS. Trying to run example 3 will result in exceptions at runtime due to the fact that javaFx is used.
Long story short: you cannot run programs that involve a gui in a docker container (that's a lie, you can, but with very specific technological stacks that does not concern this project). 

I was forced to create a Dockerfile with two stages due to the fact that the _jomifred/jacamo_ image, provided by the JaCaMo creators, does not come with gradle installed, so in the first stage I use the 6.8.0 gradle image (same version as the one called by the gradlew) to create the jar and then I run it in the second stage (where all the magical environment that JaCaMo needs is set by the _jomifred/jacamo_ image).

